### PR TITLE
Identify direct video links

### DIFF
--- a/youtube_dl/extractor/mediahuis.py
+++ b/youtube_dl/extractor/mediahuis.py
@@ -170,6 +170,11 @@ class MediahuisIE(InfoExtractor):
             url_type = 'url_transparent'
             # return self.url_result(video_url, 'Medialaan')
 
+        # Source: flvpd.vtm.be/video.medialaancdn.be
+        iframe_m = re.search(r'<script.+?[^>]+videoUrl:\'(.+?)\'', webpage)
+        if iframe_m:
+            video_url = (iframe_m.group(1))
+            
         info = {
             'url': video_url,
             'id': video_id,


### PR DESCRIPTION
Detect vtm.be and medialaancdn.be hosted mp4 videos
Ex: http://www.gva.be/cnt/dmf20170105_02660060/nieuwe-vtm-programma-groeten-uit-groeit-uit-tot-nostalgische-hit
